### PR TITLE
Update Stencil::Base to have #optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,14 @@ And then execute:
 class UserInformationStencil < Stencil::Base
   template "user_information_stencil"
   needs :user
-  attr_writer :size
+  optional size: :small
 
   def big?
     @size == :big
+  end
+
+  def small?
+    @size == :small
   end
 
   def name
@@ -49,8 +53,7 @@ end
 
 :ruby
   # initialize your stencil instance
-  user_profile = UserInformationStencil.new(user: current_user)
-  user_profile.size = :big
+  user_profile = UserInformationStencil.new(user: current_user, size: :big)
 
 = user_profile.render
 

--- a/lib/stencil/base.rb
+++ b/lib/stencil/base.rb
@@ -10,6 +10,21 @@ module Stencil
         @keys
       end
 
+      # Public: allows you to set optional fields + defaults for a Stencil.
+      #
+      # Usage:
+      #   optional size: 20  # @size defaults to 20
+      #
+      #   optional start_time: -> { Time.now }  # start_time is evaluated at
+      #                                         # template creation time
+      #
+      #   optional size: 20, color: 'xxl' # multiple values
+      def optional(options = nil)
+        @optional ||= {}
+        @optional.merge!(options) unless options.nil?
+        @optional
+      end
+
       def assert_keys(keys)
         needs.each do |key|
           if !keys.map(&:to_s).include?(key)
@@ -29,9 +44,12 @@ module Stencil
     end
 
     def initialize(options={})
+      options = options_with_defaults(options)
+
       options.each_pair do |k, v|
         self.instance_variable_set "@#{k}", v
       end
+
       self.class.assert_keys(options.keys)
     end
 
@@ -44,5 +62,30 @@ module Stencil
     end
 
     alias :render :to_html
+
+  private
+
+    def options_with_defaults(options)
+      optional_fields_with_transformations.merge(options)
+    end
+
+    # We want to compute any optional lambdas here, as well as
+    # clone any Strings/Hashes/Arrays from their defaults.
+    def optional_fields_with_transformations
+      transformed = {}
+
+      self.class.optional.each_pair do |key, value|
+        case value
+        when Hash, Array, String
+          transformed[key] = value.clone
+        when Proc
+          transformed[key] = value.call
+        else
+          transformed[key] = value
+        end
+      end
+
+      transformed
+    end
   end
 end

--- a/spec/stencil/base_spec.rb
+++ b/spec/stencil/base_spec.rb
@@ -11,7 +11,7 @@ describe Stencil::Base do
     class UserProfileStencil < Stencil::Base
       template "user_profile_stencil"
       needs :user
-      attr_writer :size
+      optional size: :small
 
       def big?
         @size == :big
@@ -22,6 +22,50 @@ describe Stencil::Base do
       end
     end
     UserProfileStencil
+  end
+
+  describe ".optional" do
+    class OptionalUserProfileStencil < Stencil::Base
+      template "user_profile_stencil"
+      needs :user
+      optional size: 16, color: 'blue', computed: -> { 2 + 2 }
+
+      attr_reader :size, :computed
+
+      def blue?
+        @color == 'blue'
+      end
+
+      def green?
+        @color == 'green'
+      end
+    end
+
+    let(:optional_class) { OptionalUserProfileStencil }
+    let(:user) { double(:user) }
+
+    subject { optional_class.new(user: user) }
+
+    it "should have defaults" do
+      expect(subject).to be_blue
+      expect(subject.size).to eq(16)
+    end
+
+    it "should allow overrides" do
+      subject = optional_class.new(user: user, size: 50, color: 'green')
+      expect(subject).to be_green
+      expect(subject.size).to eq(50)
+    end
+
+    it "should allow partial overrides" do
+      subject = optional_class.new(user: user, size: 100)
+      expect(subject).to be_blue
+      expect(subject.size).to eq(100)
+    end
+
+    it "should allow a computed block as an optional default" do
+      expect(subject.computed).to eq(4)
+    end
   end
 
   describe ".needs" do


### PR DESCRIPTION
- Added optional support
- Added lambda support to optional
- Update README to use optional instead of attr_writer
- Update all specs to use optional instead of attr_writer
